### PR TITLE
no direct access to data dictionary

### DIFF
--- a/eventline/getData.php
+++ b/eventline/getData.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once realpath(dirname(__FILE__) . '/../../../') . '/inc/init.php';
+
+if (!isset($_GET['id'])) {
+    die('no id given');
+}
+
+$id = cleanID($_GET['id']);
+
+
+if (auth_quickaclcheck($id) < AUTH_READ) {
+    header('HTTP/1.1 403 Forbidden');
+    die('access denied');
+}
+
+$path = preg_replace('/.txt$/i', '.xml', wikiFN($id));
+
+if (!file_exists($path)) {
+    header('HTTP/1.0 404 Not Found');
+    die('dosn\'t exists');
+}
+
+header('Content-Type: text/xml');
+echo file_get_contents($path);

--- a/eventline/getXmlData.php
+++ b/eventline/getXmlData.php
@@ -13,16 +13,13 @@
  */
 
 function pullInXmlData ($dokuPageId) {
-        
-    /* Initialization */
-    define('DOKU_PATH', realpath(dirname(__FILE__)) . '/../../../');
 
     // don't refresh caches
     unset($_REQUEST['purge']); 
-    require_once DOKU_PATH . '/inc/cache.php';
+    require_once DOKU_INC . '/inc/cache.php';
     
     // from id parameter, build text file path
-    $pagePath = DOKU_PATH . '/data/pages/'. str_replace(":", "/", $dokuPageId) . '.txt';
+    $pagePath = DOKU_INC . '/data/pages/'. str_replace(":", "/", $dokuPageId) . '.txt';
     
     // get cached instructions for that file
     $cache = new cache_instructions($dokuPageId, $pagePath); 

--- a/eventline/syntax.php
+++ b/eventline/syntax.php
@@ -150,13 +150,13 @@ class syntax_plugin_eventline extends DokuWiki_Syntax_Plugin {
 	  if($ID == NULL)
           $filePath = 'http://'.$_SERVER['SERVER_NAME'].'/'. TL_ROOT. '/assets/files/timelines'. str_replace(":", "/", $dataFile) . '.xml';
 	  else
-          $filePath = DOKU_URL . 'data/pages/'. str_replace(":", "/", $dataFile) . '.xml';
+          $filePath = DOKU_URL . 'lib/plugins/eventline/getData.php?id='.urlencode($dataFile);
 
       // Set timeline div & class for css styling and jsvascript id
 	  $R->doc .='<div id="eventlineplugin__timeline" class="eventlineplugin__class" style="height:'.$height.';"></div>';
 	  
 	  // Add a link to the data file for dokuwiki editing (.txt) version
-	  $R->doc .='<div id="eventlineplugin__data"> Go to <a title="' . $dataFile .'" class="wikilink1" href="doku.php?id=' . $dataFile . '">'.$data['file'].'</a> data</div>';
+	  $R->doc .='<div id="eventlineplugin__data"> Go to <a title="' . $dataFile .'" class="wikilink1" href="' . wl($dataFile) . '">'.$data['file'].'</a> data</div>';
 
 	  // Add a div for timeline filter controls if selected
 	  if ($controls=='on'){

--- a/eventline/syntax.php
+++ b/eventline/syntax.php
@@ -164,9 +164,9 @@ class syntax_plugin_eventline extends DokuWiki_Syntax_Plugin {
 	  }
 
 	  // onload invoke timeline javascript 
-	  $R->doc .='<script> window.onload = onLoad("'.$filePath.'" , '.$bubbleHeight.', '.$bubbleWidth.', "'.$mouse.'", "'.$center.'", "'
-	  .$controls.'", "'.$bandPos.'", "'.$detailPercent.'", "'.$overPercent.'", "'.$detailPixels.'", "'.$overPixels.'", "'.$detailInterval.'", "'.$overInterval.'");   </script>';	  
-	  $R->doc .='<script> window.onresize=onResize(); </script> ';
+	  $R->doc .='<script>window.onLoad = onLoad("'.$filePath.'" , '.$bubbleHeight.', '.$bubbleWidth.', "'.$mouse.'", "'.$center.'", "'
+	  .$controls.'", "'.$bandPos.'", "'.$detailPercent.'", "'.$overPercent.'", "'.$detailPixels.'", "'.$overPixels.'", "'.$detailInterval.'", "'.$overInterval.'");</script>' . "\n";
+	  $R->doc .='<script>window.onResize=onResize();</script> ';
 	  return true;
     }
 }


### PR DESCRIPTION
Fixes the direct access to DokuWiki data dictionary. It'll use a PHP gateway. It will use the ACL to check permissions.

It also fixes a IE8 JS warning.
